### PR TITLE
Fix invalid protobuf specs

### DIFF
--- a/chat/browser/common/libs/chat.js
+++ b/chat/browser/common/libs/chat.js
@@ -8,19 +8,19 @@ message Request {
     UPDATE_PEER = 1;
   }
 
-  required Type type = 0;
-  optional SendMessage sendMessage = 1;
-  optional UpdatePeer updatePeer = 2;
+  required Type type = 1;
+  optional SendMessage sendMessage = 2;
+  optional UpdatePeer updatePeer = 3;
 }
 
 message SendMessage {
-  required bytes data = 0;
-  required int64 created = 1;
-  required bytes id = 2;
+  required bytes data = 1;
+  required int64 created = 2;
+  required bytes id = 3;
 }
 
 message UpdatePeer {
-  optional bytes userHandle = 0;
+  optional bytes userHandle = 1;
 }
 `)
 

--- a/chat/nodejs/06-Pubsub/chat.js
+++ b/chat/nodejs/06-Pubsub/chat.js
@@ -7,19 +7,19 @@ message Request {
     UPDATE_PEER = 1;
   }
 
-  required Type type = 0;
-  optional SendMessage sendMessage = 1;
-  optional UpdatePeer updatePeer = 2;
+  required Type type = 1;
+  optional SendMessage sendMessage = 2;
+  optional UpdatePeer updatePeer = 3;
 }
 
 message SendMessage {
-  required bytes data = 0;
-  required int64 created = 1;
-  required bytes id = 2;
+  required bytes data = 1;
+  required int64 created = 2;
+  required bytes id = 3;
 }
 
 message UpdatePeer {
-  optional bytes userHandle = 0;
+  optional bytes userHandle = 1;
 }
 `)
 

--- a/chat/nodejs/08-End/chat.js
+++ b/chat/nodejs/08-End/chat.js
@@ -7,19 +7,19 @@ message Request {
     UPDATE_PEER = 1;
   }
 
-  required Type type = 0;
-  optional SendMessage sendMessage = 1;
-  optional UpdatePeer updatePeer = 2;
+  required Type type = 1;
+  optional SendMessage sendMessage = 2;
+  optional UpdatePeer updatePeer = 3;
 }
 
 message SendMessage {
-  required bytes data = 0;
-  required int64 created = 1;
-  required bytes id = 2;
+  required bytes data = 1;
+  required int64 created = 2;
+  required bytes id = 3;
 }
 
 message UpdatePeer {
-  optional bytes userHandle = 0;
+  optional bytes userHandle = 1;
 }
 `)
 

--- a/chat/nodejs/bootstrap/chat.js
+++ b/chat/nodejs/bootstrap/chat.js
@@ -7,19 +7,19 @@ message Request {
     UPDATE_PEER = 1;
   }
 
-  required Type type = 0;
-  optional SendMessage sendMessage = 1;
-  optional UpdatePeer updatePeer = 2;
+  required Type type = 1;
+  optional SendMessage sendMessage = 2;
+  optional UpdatePeer updatePeer = 3;
 }
 
 message SendMessage {
-  required bytes data = 0;
-  required int64 created = 1;
-  required bytes id = 2;
+  required bytes data = 1;
+  required int64 created = 2;
+  required bytes id = 3;
 }
 
 message UpdatePeer {
-  optional bytes userHandle = 0;
+  optional bytes userHandle = 1;
 }
 `)
 


### PR DESCRIPTION
The protobuf compiler rejects these message definitions because they are 0 indexed, not 1 indexed. This fixes the issue and ensures cross language compatibility.