### PR TITLE
docs: add section on dealing with flaky routers

### DIFF
--- a/examples/js-libp2p-example-auto-tls/README.md
+++ b/examples/js-libp2p-example-auto-tls/README.md
@@ -159,6 +159,35 @@ automatically configure port forwarding for IPv4 and IPv6 networks:
      identify: identify(),
 ```
 
+#### Dealing with unreliable routers
+
+By default `@libp2p/upnp-nat` will use [SSDP](https://en.wikipedia.org/wiki/Simple_Service_Discovery_Protocol)
+to locate your router on the network in order to use it to map ports and
+discover it's externally routable address.
+
+Some ISP-provided routers are underpowered and require rebooting before they
+will respond to `SSDP` search messages.
+
+If you know the URL to the device descriptor of your [Internet Gateway Device](https://openconnectivity.org/developer/specifications/upnp-resources/upnp/internet-gateway-device-igd-v-2-0/)
+you can specify it manually and skip the search:
+
+```diff
+   services: {
+     autoTLS: autoTLS(),
++    upnp: uPnPNAT({
++      gateways: [
++        // manually specify URLs for device descriptor documents
++        // these can be IPv4 and/or IPv6 (if supported by your network)
++        'http://192.168.1.1:8080/path/to/descriptor.xml'
++        'http://[xx:xx:xx:xx]:8080/path/to/descriptor.xml'
++      ]
++    }),
+     identify: identify(),
+```
+
+Note that UPnP will still need to be enabled to map external ports (IPv4) and/or
+to open pinholes in the firewall if necessary (IPv6).
+
 ### Confirming dialable addresses
 
 Designing distributed systems typically involves trying to trust other system


### PR DESCRIPTION
Show how to override the location of the router device description to handle flaky routers that don't always respond to SSDP M-SEARCH messages.

## Change checklist

- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works