### PR TITLE
fix: update auto tls module name

### DIFF
--- a/examples/js-libp2p-example-auto-tls/README.md
+++ b/examples/js-libp2p-example-auto-tls/README.md
@@ -46,7 +46,7 @@ Let's configure the relevant modules:
 ```js
 import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
-import { autoTLS } from '@libp2p/auto-tls'
+import { autoTLS } from '@ipshipyard/libp2p-auto-tls'
 import { loadOrCreateSelfKey } from '@libp2p/config'
 import { identify, identifyPush } from '@libp2p/identify'
 import { keychain } from '@libp2p/keychain'
@@ -247,7 +247,7 @@ module to connect to an initial set of peers that will let us start to fill our
 routing table and perform queries:
 
 ```diff
-  import { autoTLS } from '@libp2p/auto-tls'
+  import { autoTLS } from '@ipshipyard/libp2p-auto-tls'
 + import { bootstrap } from '@libp2p/bootstrap'
   import { loadOrCreateSelfKey } from '@libp2p/config'
   import { identify, identifyPush } from '@libp2p/identify'

--- a/examples/js-libp2p-example-auto-tls/auto-confirm.js
+++ b/examples/js-libp2p-example-auto-tls/auto-confirm.js
@@ -4,7 +4,7 @@
 
 import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
-import { autoTLS } from '@libp2p/auto-tls'
+import { autoTLS } from '@ipshipyard/libp2p-auto-tls'
 import { loadOrCreateSelfKey } from '@libp2p/config'
 import { identify, identifyPush } from '@libp2p/identify'
 import { keychain } from '@libp2p/keychain'

--- a/examples/js-libp2p-example-auto-tls/package.json
+++ b/examples/js-libp2p-example-auto-tls/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@chainsafe/libp2p-noise": "^16.0.0",
     "@chainsafe/libp2p-yamux": "^7.0.0",
-    "@libp2p/auto-tls": "^1.0.0",
+    "@ipshipyard/libp2p-auto-tls": "^1.0.0",
     "@libp2p/autonat": "^2.0.13",
     "@libp2p/bootstrap": "^11.0.14",
     "@libp2p/config": "^1.0.0",

--- a/examples/js-libp2p-example-auto-tls/trust-free.js
+++ b/examples/js-libp2p-example-auto-tls/trust-free.js
@@ -4,7 +4,7 @@
 
 import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
-import { autoTLS } from '@libp2p/auto-tls'
+import { autoTLS } from '@ipshipyard/libp2p-auto-tls'
 import { autoNAT } from '@libp2p/autonat'
 import { bootstrap } from '@libp2p/bootstrap'
 import { loadOrCreateSelfKey } from '@libp2p/config'


### PR DESCRIPTION
Auto-TLS is published under `@ipshipyard/libp2p-auto-tls`

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works