### PR TITLE
docs: update relay example to use current terminology

### DIFF
--- a/examples/js-libp2p-example-circuit-relay/dialer.js
+++ b/examples/js-libp2p-example-circuit-relay/dialer.js
@@ -9,9 +9,9 @@ import { multiaddr } from '@multiformats/multiaddr'
 import { createLibp2p } from 'libp2p'
 
 async function main () {
-  const autoRelayNodeAddr = process.argv[2]
-  if (!autoRelayNodeAddr) {
-    throw new Error('the auto relay node address needs to be specified')
+  const listenNodeAddr = process.argv[2]
+  if (!listenNodeAddr) {
+    throw new Error('The listening node address needs to be specified')
   }
 
   const node = await createLibp2p({
@@ -32,8 +32,11 @@ async function main () {
 
   console.log(`Node started with id ${node.peerId.toString()}`)
 
-  const conn = await node.dial(multiaddr(autoRelayNodeAddr))
-  console.log(`Connected to the auto relay node via ${conn.remoteAddr.toString()}`)
+  const ma = multiaddr(listenNodeAddr)
+  const conn = await node.dial(ma, {
+    signal: AbortSignal.timeout(10_000)
+  })
+  console.log(`Connected to the listening node via ${conn.remoteAddr.toString()}`)
 }
 
 main()

--- a/examples/js-libp2p-example-circuit-relay/listener.js
+++ b/examples/js-libp2p-example-circuit-relay/listener.js
@@ -44,7 +44,7 @@ async function main () {
   // Wait for connection and relay to be bind for the example purpose
   node.addEventListener('self:peer:update', (evt) => {
     // Updated self multiaddrs?
-    console.log(`Advertising with a relay address of ${node.getMultiaddrs()[0].toString()}`)
+    console.log(`Listening on a relay address of ${node.getMultiaddrs()[0].toString()}`)
   })
 }
 

--- a/examples/js-libp2p-example-circuit-relay/relay.js
+++ b/examples/js-libp2p-example-circuit-relay/relay.js
@@ -12,7 +12,6 @@ async function main () {
     addresses: {
       listen: ['/ip4/0.0.0.0/tcp/0/ws']
       // TODO check "What is next?" section
-      // announce: ['/dns4/auto-relay.libp2p.io/tcp/443/wss/p2p/QmWDn2LY8nannvSWJzruUYoLZ4vV83vfCBwd8DipvdgQc3']
     },
     transports: [
       webSockets()

--- a/examples/js-libp2p-example-circuit-relay/test/index.spec.js
+++ b/examples/js-libp2p-example-circuit-relay/test/index.spec.js
@@ -20,14 +20,14 @@ process.stdout.write('listener.js\n')
 const {
   process: listener,
   matches: [, autoRelayAddr]
-} = await matchOutput(/^Advertising with a relay address of (\/ip4\/.*)$/m, 'node', [path.resolve(__dirname, '../listener.js'), relayAddress])
+} = await matchOutput(/^Listening on a relay address of (\/ip4\/.*)$/m, 'node', [path.resolve(__dirname, '../listener.js'), relayAddress])
 
 process.stdout.write('==================================================================\n')
 
 // Step 3 process
 process.stdout.write('dialer.js\n')
 
-await waitForOutput(`Connected to the auto relay node via ${autoRelayAddr}`, 'node', [path.resolve(__dirname, '../dialer.js'), autoRelayAddr])
+await waitForOutput(`Connected to the listening node via ${autoRelayAddr}`, 'node', [path.resolve(__dirname, '../dialer.js'), autoRelayAddr])
 
 listener.kill()
 relay.kill()


### PR DESCRIPTION
Updates the example to reflect current terminology.

Replace references to "auto relay" to just "relay address"

Adds section about configuring auto-tls as an alternative to manually setting up nginx/SSL

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works