### PR TITLE
fix: Broken link in js-libp2p-example-protocol-and-stream-muxing Readme file.

### DIFF
--- a/examples/js-libp2p-example-protocol-and-stream-muxing/README.md
+++ b/examples/js-libp2p-example-protocol-and-stream-muxing/README.md
@@ -21,7 +21,7 @@ multistream-select at its
 Let's see *protocol multiplexing* in action! You will need the following modules
 for this example: `libp2p`, `@libp2p/tcp`, `@libp2p/peer-id`, `it-pipe`,
 `it-buffer` and `streaming-iterables`. This example reuses the base left by the
-[Transports](../transports) example. You can see the complete solution at
+[Transports](../js-libp2p-example-transports/) example. You can see the complete solution at
 [1.js](./1.js).
 
 After creating the nodes, we need to tell libp2p which protocols to handle.


### PR DESCRIPTION
## Title
<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/main.yml#L235-L242>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/semantic-pull-request.yml>
--->
fix: Broken link in js-libp2p-example-protocol-and-stream-muxing Readme file.
## Description
This PR updates a broken reference links that was pointing to outdated paths of the js-libp2p-example-transports repository. The links have been updated to point to the correct locations in the current repository structure.
<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/libp2p/js-libp2p/issues/ABCD.
Fixes https://github.com/libp2p/js-libp2p/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works