### PR TITLE
fix: add ping service where dht is used

### DIFF
--- a/examples/js-libp2p-example-auto-tls/README.md
+++ b/examples/js-libp2p-example-auto-tls/README.md
@@ -253,6 +253,7 @@ routing table and perform queries:
   import { identify, identifyPush } from '@libp2p/identify'
 + import { kadDHT, removePrivateAddressesMapper } from '@libp2p/kad-dht'
   import { keychain } from '@libp2p/keychain'
++ import { ping } from '@libp2p/ping'
 + import { tcp } from '@libp2p/tcp'
   import { uPnPNAT } from '@libp2p/upnp-nat'
 ```
@@ -282,6 +283,7 @@ routing table and perform queries:
 +    }),
      upnp: uPnPNAT(),
      identify: identify(),
++    ping: ping(),
 ```
 
 If you are running on your own network which has better support for varied

--- a/examples/js-libp2p-example-auto-tls/package.json
+++ b/examples/js-libp2p-example-auto-tls/package.json
@@ -25,6 +25,7 @@
     "@libp2p/identify": "^3.0.13",
     "@libp2p/kad-dht": "^14.1.4",
     "@libp2p/keychain": "^5.0.11",
+    "@libp2p/ping": "^2.0.27",
     "@libp2p/upnp-nat": "^3.0.1",
     "@libp2p/websockets": "^9.1.0",
     "@multiformats/multiaddr-matcher": "^1.6.0",

--- a/examples/js-libp2p-example-auto-tls/trust-free.js
+++ b/examples/js-libp2p-example-auto-tls/trust-free.js
@@ -11,6 +11,7 @@ import { loadOrCreateSelfKey } from '@libp2p/config'
 import { identify, identifyPush } from '@libp2p/identify'
 import { kadDHT, removePrivateAddressesMapper } from '@libp2p/kad-dht'
 import { keychain } from '@libp2p/keychain'
+import { ping } from '@libp2p/ping'
 import { tcp } from '@libp2p/tcp'
 import { uPnPNAT } from '@libp2p/upnp-nat'
 import { webSockets } from '@libp2p/websockets'
@@ -46,6 +47,7 @@ const libp2p = await createLibp2p({
     // needed to run KAD-DHT and to be contacted by libp2p.direct
     identify: identify(),
     identifyPush: identifyPush(),
+    ping: ping(),
 
     // used to securely store the certificate for use after a restart
     keychain: keychain(),

--- a/examples/js-libp2p-example-discovery-mechanisms/1-dht.js
+++ b/examples/js-libp2p-example-discovery-mechanisms/1-dht.js
@@ -5,6 +5,7 @@ import { yamux } from '@chainsafe/libp2p-yamux'
 import { bootstrap } from '@libp2p/bootstrap'
 import { identify } from '@libp2p/identify'
 import { kadDHT, removePublicAddressesMapper } from '@libp2p/kad-dht'
+import { ping } from '@libp2p/ping'
 import { tcp } from '@libp2p/tcp'
 import { createLibp2p } from 'libp2p'
 import bootstrappers from './bootstrappers.js'
@@ -27,7 +28,8 @@ const node = await createLibp2p({
       peerInfoMapper: removePublicAddressesMapper,
       clientMode: false
     }),
-    identify: identify()
+    identify: identify(),
+    ping: ping()
   }
 })
 

--- a/examples/js-libp2p-example-discovery-mechanisms/package.json
+++ b/examples/js-libp2p-example-discovery-mechanisms/package.json
@@ -24,6 +24,7 @@
     "@libp2p/identify": "^3.0.0",
     "@libp2p/kad-dht": "^14.0.0",
     "@libp2p/mdns": "^11.0.0",
+    "@libp2p/ping": "^2.0.27",
     "@libp2p/pubsub-peer-discovery": "^11.0.0",
     "@libp2p/tcp": "^10.0.0",
     "libp2p": "^2.0.0"

--- a/examples/js-libp2p-example-peer-and-content-routing/1.js
+++ b/examples/js-libp2p-example-peer-and-content-routing/1.js
@@ -4,6 +4,7 @@ import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
 import { identify, identifyPush } from '@libp2p/identify'
 import { kadDHT, removePublicAddressesMapper } from '@libp2p/kad-dht'
+import { ping } from '@libp2p/ping'
 import { tcp } from '@libp2p/tcp'
 import { createLibp2p } from 'libp2p'
 
@@ -23,7 +24,8 @@ const createNode = async () => {
         clientMode: false
       }),
       identify: identify(),
-      identifyPush: identifyPush()
+      identifyPush: identifyPush(),
+      ping: ping()
     }
   })
 

--- a/examples/js-libp2p-example-peer-and-content-routing/2.js
+++ b/examples/js-libp2p-example-peer-and-content-routing/2.js
@@ -4,6 +4,7 @@ import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
 import { identify, identifyPush } from '@libp2p/identify'
 import { kadDHT, removePublicAddressesMapper } from '@libp2p/kad-dht'
+import { ping } from '@libp2p/ping'
 import { tcp } from '@libp2p/tcp'
 import all from 'it-all'
 import { createLibp2p } from 'libp2p'
@@ -24,7 +25,8 @@ const createNode = async () => {
         clientMode: false
       }),
       identify: identify(),
-      identifyPush: identifyPush()
+      identifyPush: identifyPush(),
+      ping: ping()
     }
   })
 

--- a/examples/js-libp2p-example-peer-and-content-routing/README.md
+++ b/examples/js-libp2p-example-peer-and-content-routing/README.md
@@ -22,6 +22,7 @@ import { noise } from '@chainsafe/libp2p-noise'
 import { yamux } from '@chainsafe/libp2p-yamux'
 import { identify, identifyPush } from '@libp2p/identify'
 import { kadDHT, removePublicAddressesMapper } from '@libp2p/kad-dht'
+import { ping } from '@libp2p/ping'
 import { tcp } from '@libp2p/tcp'
 import { createLibp2p } from 'libp2p'
 
@@ -41,7 +42,8 @@ const createNode = async () => {
         clientMode: false
       }),
       identify: identify(),
-      identifyPush: identifyPush()
+      identifyPush: identifyPush(),
+      ping: ping()
     }
   })
 

--- a/examples/js-libp2p-example-peer-and-content-routing/package.json
+++ b/examples/js-libp2p-example-peer-and-content-routing/package.json
@@ -21,6 +21,7 @@
     "@chainsafe/libp2p-yamux": "^7.0.0",
     "@libp2p/identify": "^3.0.1",
     "@libp2p/kad-dht": "^14.0.0",
+    "@libp2p/ping": "^2.0.27",
     "@libp2p/tcp": "^10.0.0",
     "it-all": "^3.0.2",
     "libp2p": "^2.0.0",


### PR DESCRIPTION
The next major release of the `@libp2p/kad-dht` module introduces a dependency on `@libp2p/ping` so make sure it's in the config.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works