### PR TITLE
Testing with external peers

### DIFF
--- a/examples/js-libp2p-example-webrtc-private-to-private/README.md
+++ b/examples/js-libp2p-example-webrtc-private-to-private/README.md
@@ -30,6 +30,13 @@ At this point the browsers are directly connected and the relay plays no further
 
 ## Running the Example
 
+### Hosting and Network Configuration
+- To allow external access to the web interface, host this example on a machine that exposes web connectivity over port 5173.
+- #### If running on AWS EC2:
+  Open your EC2 instance’s Security Group settings and create an inbound TCP rule for port 5173.
+- Tip: Assign a static public IP to your machine so it remains reachable at the same address.
+- The web server scripts have been updated to listen on all network interfaces (0.0.0.0). This allows access from external clients, not just localhost.
+
 ### Build the `@libp2p/example-webrtc-private-to-private` package
 
 Build example by calling `npm i && npm run build` in the repository root.
@@ -64,6 +71,8 @@ Now open a second tab with the url `http://localhost:5173/`, perhaps in a differ
 Using the copied multiaddress from `Listening on` section in `Browser A`, paste it into the `Remote MultiAddress` input and click the `Connect` button.
 
 The peers are now connected to each other.
+### Connection Type Indicator
+- When a connection is established between peers, the UI now displays whether the connection is Direct or via Relay next to the connected address.
 
 Enter a message and click the `Send` button in either/both browsers and see the echo'd messages.
 

--- a/examples/js-libp2p-example-webrtc-private-to-private/index.js
+++ b/examples/js-libp2p-example-webrtc-private-to-private/index.js
@@ -58,17 +58,27 @@ const node = await createLibp2p({
 
 await node.start()
 
-function updateConnList () {
+function updateConnList() {
   // Update connections list
   const connListEls = node.getConnections()
     .map((connection) => {
+      const isRelayed = connection.remoteAddr.protoCodes().includes('p2p-circuit')
+      const connectionType = isRelayed ? 'Relay' : 'Direct'
+
       if (connection.remoteAddr.protoCodes().includes(WEBRTC_CODE)) {
         ma = connection.remoteAddr
         sendSection.style.display = 'block'
       }
 
       const el = document.createElement('li')
-      el.textContent = connection.remoteAddr.toString()
+      el.textContent = `${connection.remoteAddr.toString()} (${connectionType})`
+
+      // Set color based on connection type
+      el.style.color = isRelayed ? 'black' : 'green'
+
+      const icon = document.createElement('span')
+      icon.textContent = isRelayed ? '🔄' : '✅'
+      el.appendChild(icon)
       return el
     })
   document.getElementById('connections').replaceChildren(...connListEls)

--- a/examples/js-libp2p-example-webrtc-private-to-private/package.json
+++ b/examples/js-libp2p-example-webrtc-private-to-private/package.json
@@ -4,7 +4,7 @@
   "description": "Connect a browser to another browser",
   "type": "module",
   "scripts": {
-    "start": "vite",
+    "start": "vite --host 0.0.0.0",
     "build": "vite build",
     "relay": "node relay.js",
     "test:firefox": "npm run build && playwright test --browser=firefox test",

--- a/examples/js-libp2p-example-webrtc-private-to-private/package.json
+++ b/examples/js-libp2p-example-webrtc-private-to-private/package.json
@@ -20,6 +20,7 @@
     "@libp2p/webrtc": "^5.0.0",
     "@libp2p/websockets": "^9.0.0",
     "@multiformats/multiaddr": "^12.0.0",
+    "it-byte-stream": "^2.0.2",
     "it-pushable": "^3.2.0",
     "libp2p": "^2.0.0",
     "vite": "^6.0.3"


### PR DESCRIPTION
## Title
<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/main.yml#L235-L242>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/libp2p/js-libp2p/blob/master/.github/workflows/semantic-pull-request.yml>
--->

## Description
This PR updates the js-libp2p-example-webrtc-private-to-private example to support and document testing peer-to-peer connectivity in realistic network conditions, such as when peers are:

Running on separate machines
Behind NATs or VPNs
Without public IPs
Key changes include:

Binding the development server to all interfaces (0.0.0.0), so the example is reachable from external machines.
Documentation for exposing port 5173, including guidance for environments like AWS EC2.
Recommendation to use a static public IP for the signaling server host to avoid connectivity issues.
Connection type indicator: The UI now displays whether a peer connection is established Directly or via a Relay.
Fixes https://github.com/libp2p/js-libp2p-examples/issues/226.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works